### PR TITLE
Add NIL valuation pipeline scaffold

### DIFF
--- a/api/__init__.py
+++ b/api/__init__.py
@@ -1,0 +1,5 @@
+"""FastAPI application package for NIL valuations."""
+
+from .main import app
+
+__all__ = ["app"]

--- a/api/cache.py
+++ b/api/cache.py
@@ -1,0 +1,57 @@
+"""Caching utilities backed by Redis with graceful fallback."""
+
+from __future__ import annotations
+
+import json
+import logging
+from datetime import timedelta
+from typing import Any, Optional
+
+import redis
+
+from bsi_nil.config import load_config
+
+logger = logging.getLogger(__name__)
+
+
+class CacheClient:
+    """Simple key/value cache with JSON serialization."""
+
+    def __init__(self) -> None:
+        config = load_config()
+        redis_cfg = config["redis"]
+        self.ttl = redis_cfg.get("ttl_seconds", 900)
+        self._memory_store: dict[str, tuple[Any, float]] = {}
+        try:
+            self.client: Optional[redis.Redis] = redis.Redis(
+                host=redis_cfg.get("host", "localhost"),
+                port=redis_cfg.get("port", 6379),
+                socket_timeout=1,
+                socket_connect_timeout=1,
+                decode_responses=True,
+            )
+            # Probe connection
+            self.client.ping()
+        except redis.RedisError as exc:  # pragma: no cover - network failure scenario
+            logger.warning("Redis unavailable, falling back to in-memory cache: %s", exc)
+            self.client = None
+            self._memory_store: dict[str, tuple[Any, float]] = {}
+
+    def _serialize(self, value: Any) -> str:
+        return json.dumps(value, default=str)
+
+    def _deserialize(self, value: str) -> Any:
+        return json.loads(value)
+
+    def get(self, key: str) -> Optional[Any]:
+        if self.client is not None:
+            payload = self.client.get(key)
+            return self._deserialize(payload) if payload else None
+        value, _ = self._memory_store.get(key, (None, 0))
+        return value
+
+    def set(self, key: str, value: Any) -> None:
+        if self.client is not None:
+            self.client.setex(key, timedelta(seconds=self.ttl), self._serialize(value))
+        else:
+            self._memory_store[key] = (value, self.ttl)

--- a/api/main.py
+++ b/api/main.py
@@ -1,0 +1,88 @@
+"""FastAPI service exposing NIL valuations."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import List
+
+from fastapi import FastAPI, HTTPException
+
+from api.cache import CacheClient
+from api.schemas import AthleteValuationResponse, LeaderboardEntry, LeaderboardResponse, ValuationDriver
+from bsi_nil.config import load_config
+from models import repository
+
+app = FastAPI(title="Blaze Sports Intel NIL Valuations", version="1.0.0")
+cache = CacheClient()
+config = load_config()
+
+
+@app.on_event("startup")
+def on_startup() -> None:
+    repository.initialize_database()
+
+
+@app.get("/athlete/{athlete_id}/value", response_model=AthleteValuationResponse)
+def get_athlete_value(athlete_id: str) -> AthleteValuationResponse:
+    cache_key = f"athlete:{athlete_id}"
+    cached = cache.get(cache_key)
+    if cached:
+        return AthleteValuationResponse(**cached)
+
+    valuation = repository.fetch_athlete_valuation(athlete_id)
+    if valuation is None:
+        raise HTTPException(status_code=404, detail="Athlete not found")
+
+    response = AthleteValuationResponse(
+        athlete_id=valuation["athlete_id"],
+        name=valuation["name"],
+        sport=valuation["sport"],
+        school=valuation["school"],
+        as_of=valuation["as_of"],
+        nil_value=valuation["nil_value"],
+        confidence_lower=valuation["confidence_lower"],
+        confidence_upper=valuation["confidence_upper"],
+        drivers=ValuationDriver(
+            attention_score=valuation["attention_score"],
+            performance_index=valuation["performance_index"],
+        ),
+        disclaimer=config["project"]["disclaimer"],
+    )
+    cache.set(cache_key, response.model_dump())
+    return response
+
+
+@app.get("/leaderboard", response_model=LeaderboardResponse)
+def get_leaderboard(limit: int = 100) -> LeaderboardResponse:
+    cache_key = f"leaderboard:{limit}"
+    cached = cache.get(cache_key)
+    if cached:
+        return LeaderboardResponse(**cached)
+
+    leaderboard_rows = repository.fetch_leaderboard(limit=limit)
+    if not leaderboard_rows:
+        raise HTTPException(status_code=404, detail="Leaderboard unavailable")
+
+    results: List[LeaderboardEntry] = []
+    baseline = leaderboard_rows[0]["nil_value"] if leaderboard_rows else 0
+    for idx, row in enumerate(leaderboard_rows, start=1):
+        trend = (row["nil_value"] - baseline) / baseline if baseline else 0.0
+        results.append(
+            LeaderboardEntry(
+                rank=idx,
+                athlete_id=row["athlete_id"],
+                name=row["name"],
+                sport=row["sport"],
+                school=row["school"],
+                nil_value=row["nil_value"],
+                trend=trend,
+            )
+        )
+
+    response = LeaderboardResponse(
+        generated_at=datetime.now(UTC),
+        results=results,
+        disclaimer=config["project"]["disclaimer"],
+    )
+    cache.set(cache_key, response.model_dump())
+    return response

--- a/api/schemas.py
+++ b/api/schemas.py
@@ -1,0 +1,42 @@
+"""Pydantic schemas for FastAPI responses."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import List
+
+from pydantic import BaseModel, Field
+
+
+class ValuationDriver(BaseModel):
+    attention_score: float = Field(..., description="Model attention score")
+    performance_index: float = Field(..., description="Model performance index")
+
+
+class AthleteValuationResponse(BaseModel):
+    athlete_id: str
+    name: str
+    sport: str
+    school: str
+    as_of: datetime
+    nil_value: float
+    confidence_lower: float
+    confidence_upper: float
+    drivers: ValuationDriver
+    disclaimer: str
+
+
+class LeaderboardEntry(BaseModel):
+    rank: int
+    athlete_id: str
+    name: str
+    sport: str
+    school: str
+    nil_value: float
+    trend: float
+
+
+class LeaderboardResponse(BaseModel):
+    generated_at: datetime
+    results: List[LeaderboardEntry]
+    disclaimer: str

--- a/bsi_nil/__init__.py
+++ b/bsi_nil/__init__.py
@@ -1,0 +1,5 @@
+"""Core package for Blaze Sports Intel NIL valuation pipeline."""
+
+from .config import load_config
+
+__all__ = ["load_config"]

--- a/bsi_nil/config.py
+++ b/bsi_nil/config.py
@@ -1,0 +1,58 @@
+"""Configuration utilities for the Blaze Sports Intel NIL pipeline."""
+
+from __future__ import annotations
+
+import os
+from functools import lru_cache
+from pathlib import Path
+from typing import Any, Dict
+
+import yaml
+
+
+class ConfigError(RuntimeError):
+    """Raised when configuration cannot be loaded or parsed."""
+
+
+@lru_cache(maxsize=1)
+def load_config(path: str | Path | None = None) -> Dict[str, Any]:
+    """Load YAML configuration and cache the parsed dictionary.
+
+    Args:
+        path: Optional explicit path to the YAML config file. If omitted,
+            the function will look for the ``BLAZE_CONFIG`` environment
+            variable and fall back to ``config/settings.yaml`` relative to the
+            project root.
+
+    Returns:
+        Parsed configuration dictionary.
+
+    Raises:
+        ConfigError: If the file cannot be read or parsed.
+    """
+
+    config_path = Path(
+        path
+        or os.getenv("BLAZE_CONFIG")
+        or Path(__file__).resolve().parent.parent / "config" / "settings.yaml"
+    )
+
+    if not config_path.exists():
+        raise ConfigError(f"Configuration file not found: {config_path}")
+
+    try:
+        with config_path.open("r", encoding="utf-8") as f:
+            data = yaml.safe_load(f)
+    except yaml.YAMLError as exc:  # pragma: no cover - explicit error propagation
+        raise ConfigError("Invalid YAML configuration") from exc
+
+    if not isinstance(data, dict):
+        raise ConfigError("Configuration root must be a mapping")
+
+    return data
+
+
+def reset_config_cache() -> None:
+    """Clear cached configuration for test isolation."""
+
+    load_config.cache_clear()

--- a/config/settings.yaml
+++ b/config/settings.yaml
@@ -1,0 +1,60 @@
+# Blaze Sports Intel NIL Pipeline configuration
+project:
+  name: "Blaze Sports Intel NIL Valuation"
+  disclaimer: "Estimated value, not contractual."
+
+logging:
+  level: "INFO"
+
+database:
+  url: "postgresql+psycopg2://postgres:postgres@localhost:5432/blaze_nil"
+  echo: false
+
+storage:
+  raw_path: "storage/raw"
+
+redis:
+  host: "localhost"
+  port: 6379
+  ttl_seconds: 900
+
+features:
+  attention_weights:
+    social_followers: 0.5
+    social_engagement: 0.3
+    search_interest: 0.2
+  attention_decay_days: 14
+  performance_weights:
+    points: 0.4
+    assists: 0.2
+    rebounds: 0.2
+    efficiency: 0.2
+  market_adjustment:
+    Baseball: 1.05
+    Football: 1.15
+    Basketball: 1.10
+    "Track & Field": 0.95
+
+modeling:
+  stage_a_params:
+    learning_rate: 0.1
+    n_estimators: 100
+    max_depth: 3
+  stage_b_params:
+    learning_rate: 0.1
+    n_estimators: 200
+    max_depth: 4
+  shrinkage_prior: 0.5
+  shrinkage_strength: 10.0
+
+context:
+  schools:
+    BSI University:
+      market_size: 1.2
+      tv_exposure: 0.9
+    Summit College:
+      market_size: 0.8
+      tv_exposure: 0.7
+    Redwood State:
+      market_size: 1.5
+      tv_exposure: 1.1

--- a/etl/__init__.py
+++ b/etl/__init__.py
@@ -1,0 +1,5 @@
+"""ETL package for data ingestion flows."""
+
+from .flows import nightly_pipeline
+
+__all__ = ["nightly_pipeline"]

--- a/etl/flows.py
+++ b/etl/flows.py
@@ -1,0 +1,145 @@
+"""Prefect flow orchestrating the NIL valuation pipeline."""
+
+from __future__ import annotations
+
+from prefect import flow, get_run_logger, task
+
+from bsi_nil.config import load_config
+from etl import mock_sources
+from etl.normalization import build_id_map, normalize_ids
+from etl.raw_storage import RawStorageClient
+from models import backtest, features as feature_eng
+from models import repository, training
+
+
+@task
+def ingest_sources():
+    logger = get_run_logger()
+    logger.info("Loading mock data sources for Blaze Intelligence")
+    athletes = mock_sources.load_athlete_directory()
+    box_scores = mock_sources.generate_box_scores()
+    social = mock_sources.generate_social_stats()
+    search = mock_sources.generate_search_interest()
+    nil_deals = mock_sources.get_mock_nil_deals()
+    return athletes, box_scores, social, search, nil_deals
+
+
+@task
+def persist_raw(athletes, box_scores, social, search, nil_deals):
+    storage = RawStorageClient()
+    storage.save_dataframe(athletes, "athletes")
+    storage.save_dataframe(box_scores, "box_scores")
+    storage.save_dataframe(social, "social_stats")
+    storage.save_dataframe(search, "search_interest")
+    storage.save_dataframe(nil_deals, "nil_deals")
+
+
+@task
+def load_warehouse(athletes, box_scores, social, search):
+    repository.initialize_database()
+    repository.upsert_athletes(athletes)
+    repository.load_box_scores(box_scores)
+    repository.load_social_stats(social)
+    repository.load_search_interest(search)
+
+
+@task
+def engineer_features(athletes, box_scores, social, search):
+    attention = feature_eng.compute_attention_scores(social, search)
+    performance = feature_eng.compute_performance_index(box_scores)
+    enriched = feature_eng.join_with_context(athletes, attention, performance)
+    repository.store_features(
+        enriched[[
+            "athlete_id",
+            "as_of",
+            "attention_score",
+            "performance_index",
+        ]]
+    )
+    return enriched
+
+
+@task
+def train_and_score(features_df, social, search, nil_deals, box_scores):
+    models, artifacts, stage_a_predictions = training.train_models(
+        social_stats=social,
+        search_interest=search,
+        features=features_df[[
+            "athlete_id",
+            "attention_score",
+            "performance_index",
+            "context_multiplier",
+            "adjusted_performance",
+        ]].assign(attention_score=features_df["attention_score"]),
+        nil_deals=nil_deals,
+    )
+    game_counts = box_scores.groupby("athlete_id").size()
+    valuations = training.generate_valuations(
+        features=features_df[[
+            "athlete_id",
+            "attention_score",
+            "performance_index",
+            "context_multiplier",
+            "adjusted_performance",
+        ]],
+        stage_a_predictions=stage_a_predictions,
+        models=models,
+        game_counts=game_counts,
+    )
+    repository.store_valuations(valuations)
+    return valuations, artifacts
+
+
+@task
+def run_backtest(valuations, nil_deals):
+    result = backtest.backtest(valuations, nil_deals)
+    return result
+
+
+@flow(name="blaze_nil_nightly")
+def nightly_pipeline():
+    config = load_config()
+    logger = get_run_logger()
+    logger.info("Starting Blaze Intelligence NIL valuation pipeline")
+
+    (
+        athletes,
+        box_scores,
+        social,
+        search,
+        nil_deals,
+    ) = ingest_sources()
+
+    id_map = build_id_map(athletes)
+    box_scores = normalize_ids(box_scores, "athlete_id", id_map)
+    social = normalize_ids(social, "athlete_id", id_map)
+    search = normalize_ids(search, "athlete_id", id_map)
+    nil_deals = normalize_ids(nil_deals, "athlete_id", id_map)
+
+    persist_raw(athletes, box_scores, social, search, nil_deals)
+    load_warehouse(athletes, box_scores, social, search)
+
+    features_df = engineer_features(athletes, box_scores, social, search)
+    valuations, artifacts = train_and_score(features_df, social, search, nil_deals, box_scores)
+    backtest_result = run_backtest(valuations, nil_deals)
+
+    logger.info(
+        "Training RMSE stage_a=%.2f stage_b=%.2f",
+        artifacts.stage_a_rmse,
+        artifacts.stage_b_rmse,
+    )
+    logger.info(
+        "Backtest coverage=%.2f mape=%.2f bias=%.2f",
+        backtest_result.coverage,
+        backtest_result.mape,
+        backtest_result.bias,
+    )
+    logger.info(config["project"]["disclaimer"])
+    return {
+        "artifacts": artifacts,
+        "backtest": backtest_result,
+    }
+
+
+if __name__ == "__main__":
+    nightly_pipeline()

--- a/etl/mock_sources.py
+++ b/etl/mock_sources.py
@@ -1,0 +1,152 @@
+"""Mock data generators for the Blaze Sports Intel NIL pipeline."""
+
+from __future__ import annotations
+
+from datetime import date, timedelta
+from typing import Dict, Iterable, List
+
+import numpy as np
+import pandas as pd
+
+ATHLETES = [
+    {
+        "athlete_id": "athlete_baseball_001",
+        "name": "Jordan Hale",
+        "sport": "Baseball",
+        "school": "BSI University",
+    },
+    {
+        "athlete_id": "athlete_baseball_002",
+        "name": "Samantha Ortiz",
+        "sport": "Baseball",
+        "school": "Summit College",
+    },
+    {
+        "athlete_id": "athlete_football_001",
+        "name": "Marcus Lee",
+        "sport": "Football",
+        "school": "Redwood State",
+    },
+    {
+        "athlete_id": "athlete_basketball_001",
+        "name": "Riley Chen",
+        "sport": "Basketball",
+        "school": "BSI University",
+    },
+    {
+        "athlete_id": "athlete_track_001",
+        "name": "Avery Patel",
+        "sport": "Track & Field",
+        "school": "Summit College",
+    },
+]
+
+
+SOCIAL_CHANNELS = ["instagram", "tiktok", "twitter"]
+
+
+def generate_box_scores(num_games: int = 5) -> pd.DataFrame:
+    """Create mock performance metrics for each athlete."""
+
+    rows: List[Dict[str, object]] = []
+    today = date.today()
+    for athlete in ATHLETES:
+        for game_index in range(num_games):
+            game_date = today - timedelta(days=game_index * 3)
+            rng = np.random.default_rng(hash((athlete["athlete_id"], game_index)) % (2**32))
+            points = rng.normal(15, 5)
+            assists = rng.normal(4, 1.5)
+            rebounds = rng.normal(6, 2)
+            efficiency = max(0.0, rng.normal(0.55, 0.05))
+            rows.append(
+                {
+                    "athlete_id": athlete["athlete_id"],
+                    "game_date": game_date,
+                    "opponent": f"Opponent {game_index + 1}",
+                    "points": round(points, 2),
+                    "assists": round(assists, 2),
+                    "rebounds": round(rebounds, 2),
+                    "efficiency": round(efficiency, 3),
+                    "minutes": round(rng.uniform(20, 35), 1),
+                }
+            )
+    return pd.DataFrame(rows)
+
+
+def generate_social_stats(days: int = 14) -> pd.DataFrame:
+    """Create mock social media follower and engagement data."""
+
+    rows: List[Dict[str, object]] = []
+    today = date.today()
+    for athlete in ATHLETES:
+        base_followers = 10_000 + hash(athlete["athlete_id"]) % 20_000
+        for offset in range(days):
+            stat_date = today - timedelta(days=offset)
+            for channel in SOCIAL_CHANNELS:
+                rng = np.random.default_rng(
+                    hash((athlete["athlete_id"], channel, offset)) % (2**32)
+                )
+                followers = base_followers * (1 + offset * 0.005) + rng.normal(0, 500)
+                engagement = rng.normal(0.08, 0.02)
+                rows.append(
+                    {
+                        "athlete_id": athlete["athlete_id"],
+                        "channel": channel,
+                        "date": stat_date,
+                        "followers": int(max(100, followers)),
+                        "engagement_rate": max(0.01, round(engagement, 3)),
+                        "growth_rate": round(rng.normal(0.01, 0.005), 3),
+                    }
+                )
+    return pd.DataFrame(rows)
+
+
+def generate_search_interest(days: int = 14) -> pd.DataFrame:
+    """Create mock Google Trends style search interest scores."""
+
+    today = date.today()
+    rows: List[Dict[str, object]] = []
+    for athlete in ATHLETES:
+        for offset in range(days):
+            stat_date = today - timedelta(days=offset)
+            rng = np.random.default_rng(
+                hash(("search", athlete["athlete_id"], offset)) % (2**32)
+            )
+            interest = rng.integers(20, 90)
+            rows.append(
+                {
+                    "athlete_id": athlete["athlete_id"],
+                    "date": stat_date,
+                    "interest_score": int(interest),
+                }
+            )
+    return pd.DataFrame(rows)
+
+
+def load_athlete_directory() -> pd.DataFrame:
+    """Return canonical athlete metadata for ID normalization."""
+
+    return pd.DataFrame(ATHLETES)
+
+
+def get_mock_nil_deals() -> pd.DataFrame:
+    """Simulate NIL deals for backtesting comparisons."""
+
+    rows: Iterable[Dict[str, object]] = [
+        {
+            "athlete_id": "athlete_baseball_001",
+            "deal_date": date.today() - timedelta(days=7),
+            "value": 25000,
+        },
+        {
+            "athlete_id": "athlete_football_001",
+            "deal_date": date.today() - timedelta(days=10),
+            "value": 120000,
+        },
+        {
+            "athlete_id": "athlete_basketball_001",
+            "deal_date": date.today() - timedelta(days=3),
+            "value": 60000,
+        },
+    ]
+    return pd.DataFrame(rows)

--- a/etl/normalization.py
+++ b/etl/normalization.py
@@ -1,0 +1,23 @@
+"""Utilities for normalizing athlete identifiers across sources."""
+
+from __future__ import annotations
+
+from typing import Dict
+
+import pandas as pd
+
+
+def build_id_map(directory: pd.DataFrame) -> Dict[str, str]:
+    """Create a lookup of alternate IDs to canonical athlete IDs."""
+
+    # In a full system we would manage crosswalk tables. For the scaffold we
+    # simply ensure the canonical ID maps to itself.
+    return {row["athlete_id"]: row["athlete_id"] for _, row in directory.iterrows()}
+
+
+def normalize_ids(df: pd.DataFrame, id_column: str, id_map: Dict[str, str]) -> pd.DataFrame:
+    """Replace identifiers in ``id_column`` using the provided lookup."""
+
+    df = df.copy()
+    df[id_column] = df[id_column].map(id_map).fillna(df[id_column])
+    return df

--- a/etl/raw_storage.py
+++ b/etl/raw_storage.py
@@ -1,0 +1,35 @@
+"""Local filesystem storage to emulate S3 for raw ingested data."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Dict
+
+import pandas as pd
+
+from bsi_nil.config import load_config
+
+
+class RawStorageClient:
+    """Persist raw data artifacts to the configured storage path."""
+
+    def __init__(self, base_path: str | Path | None = None) -> None:
+        config = load_config()
+        self.base_path = Path(base_path or config["storage"]["raw_path"])
+        self.base_path.mkdir(parents=True, exist_ok=True)
+
+    def save_dataframe(self, df: pd.DataFrame, name: str) -> Path:
+        """Write a DataFrame to CSV under the storage root."""
+
+        path = self.base_path / f"{name}.csv"
+        df.to_csv(path, index=False)
+        return path
+
+    def save_json(self, data: Dict[str, Any], name: str) -> Path:
+        """Write JSON payload to disk."""
+
+        path = self.base_path / f"{name}.json"
+        with path.open("w", encoding="utf-8") as fh:
+            json.dump(data, fh, indent=2, default=str)
+        return path

--- a/models/__init__.py
+++ b/models/__init__.py
@@ -1,0 +1,8 @@
+"""Model package exports for Blaze Sports Intel NIL pipeline."""
+
+__all__ = [
+    "backtest",
+    "features",
+    "repository",
+    "training",
+]

--- a/models/backtest.py
+++ b/models/backtest.py
@@ -1,0 +1,37 @@
+"""Backtesting utilities for the NIL valuation pipeline."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+import pandas as pd
+from sklearn.metrics import mean_absolute_percentage_error
+
+
+@dataclass
+class BacktestResult:
+    mape: float
+    bias: float
+    coverage: float
+
+
+def backtest(valuations: pd.DataFrame, deals: pd.DataFrame) -> BacktestResult:
+    """Compare generated valuations against observed NIL deals."""
+
+    if valuations.empty or deals.empty:
+        return BacktestResult(mape=float("nan"), bias=float("nan"), coverage=0.0)
+
+    merged = valuations.merge(deals, on="athlete_id", how="inner")
+    if merged.empty:
+        return BacktestResult(mape=float("nan"), bias=float("nan"), coverage=0.0)
+
+    y_true = merged["value"].to_numpy()
+    y_pred = merged["nil_value"].to_numpy()
+    lower = merged["confidence_lower"].to_numpy()
+    upper = merged["confidence_upper"].to_numpy()
+
+    mape = float(mean_absolute_percentage_error(y_true, y_pred))
+    bias = float(np.mean(y_pred - y_true))
+    coverage = float(np.mean((y_true >= lower) & (y_true <= upper)))
+    return BacktestResult(mape=mape, bias=bias, coverage=coverage)

--- a/models/database.py
+++ b/models/database.py
@@ -1,0 +1,68 @@
+"""Database utilities and SQLAlchemy session management."""
+
+from __future__ import annotations
+
+import contextlib
+import logging
+import os
+from typing import Iterator
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session, sessionmaker
+
+from bsi_nil.config import load_config
+
+logger = logging.getLogger(__name__)
+
+_ENGINE = None
+_SESSION_FACTORY = None
+
+
+def _create_engine():
+    config = load_config()
+    database_url = os.getenv("DATABASE_URL", config["database"]["url"])
+    echo = config["database"].get("echo", False)
+
+    engine = create_engine(database_url, echo=echo, future=True)
+    return engine
+
+
+def get_engine():
+    global _ENGINE
+    if _ENGINE is None:
+        _ENGINE = _create_engine()
+    return _ENGINE
+
+
+def get_session_factory():
+    global _SESSION_FACTORY
+    if _SESSION_FACTORY is None:
+        engine = get_engine()
+        _SESSION_FACTORY = sessionmaker(bind=engine, class_=Session, autoflush=False)
+    return _SESSION_FACTORY
+
+
+@contextlib.contextmanager
+def session_scope() -> Iterator[Session]:
+    """Provide a transactional scope around a series of operations."""
+
+    session_factory = get_session_factory()
+    session = session_factory()
+    try:
+        yield session
+        session.commit()
+    except Exception:  # pragma: no cover - defensive rollback
+        session.rollback()
+        raise
+    finally:
+        session.close()
+
+
+def reset_engine() -> None:
+    """Dispose of the cached SQLAlchemy engine (for tests)."""
+
+    global _ENGINE, _SESSION_FACTORY
+    if _ENGINE is not None:
+        _ENGINE.dispose()
+    _ENGINE = None
+    _SESSION_FACTORY = None

--- a/models/features.py
+++ b/models/features.py
@@ -1,0 +1,118 @@
+"""Feature engineering for NIL valuation."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import numpy as np
+import pandas as pd
+
+from bsi_nil.config import load_config
+
+
+def compute_attention_scores(
+    social_stats: pd.DataFrame,
+    search_interest: pd.DataFrame,
+) -> pd.DataFrame:
+    """Calculate attention scores with exponential decay."""
+
+    config = load_config()
+    weights = config["features"]["attention_weights"]
+    decay_days = config["features"]["attention_decay_days"]
+
+    social_daily = (
+        social_stats.groupby(["athlete_id", "date"], as_index=False)
+        .agg(
+            followers=("followers", "sum"),
+            engagement_rate=("engagement_rate", "mean"),
+            growth_rate=("growth_rate", "mean"),
+        )
+    )
+    social_daily["social_score"] = (
+        weights["social_followers"] * social_daily["followers"].rank(pct=True)
+        + weights["social_engagement"] * social_daily["engagement_rate"].rank(pct=True)
+    )
+
+    search_daily = search_interest.rename(columns={"stat_date": "date"})
+    search_daily["search_score"] = (
+        weights["search_interest"] * search_daily["interest_score"].rank(pct=True)
+    )
+
+    merged = pd.merge(
+        social_daily,
+        search_daily[["athlete_id", "date", "search_score"]],
+        on=["athlete_id", "date"],
+        how="outer",
+    ).fillna(0.0)
+
+    today = pd.Timestamp.now(tz="UTC").normalize()
+    dates = pd.to_datetime(merged["date"], utc=True)
+    merged["days_ago"] = (today - dates).dt.days
+    merged["decay_weight"] = np.exp(-merged["days_ago"] / decay_days)
+    merged["attention_score"] = (
+        (merged["social_score"] + merged["search_score"]) * merged["decay_weight"]
+    )
+
+    attention = (
+        merged.groupby("athlete_id", as_index=False)["attention_score"].sum()
+        .rename(columns={"attention_score": "attention_score"})
+        .assign(as_of=datetime.now(UTC))
+    )
+    return attention
+
+
+def compute_performance_index(box_scores: pd.DataFrame) -> pd.DataFrame:
+    """Aggregate game-level performance into a single index per athlete."""
+
+    config = load_config()
+    weights = config["features"]["performance_weights"]
+
+    performance = (
+        box_scores.groupby("athlete_id", as_index=False)
+        .agg(
+            points=("points", "mean"),
+            assists=("assists", "mean"),
+            rebounds=("rebounds", "mean"),
+            efficiency=("efficiency", "mean"),
+        )
+        .assign(as_of=datetime.now(UTC))
+    )
+
+    performance_index = pd.Series(0.0, index=performance.index, dtype=float)
+    for stat, weight in weights.items():
+        performance_index += weight * performance[stat].fillna(0.0)
+
+    performance["performance_index"] = performance_index / max(sum(weights.values()), 1e-6)
+
+    return performance[["athlete_id", "performance_index", "as_of"]]
+
+
+def join_with_context(
+    athletes: pd.DataFrame,
+    attention: pd.DataFrame,
+    performance: pd.DataFrame,
+) -> pd.DataFrame:
+    """Combine engineered features with contextual multipliers."""
+
+    config = load_config()
+    market_adjustment = config["features"]["market_adjustment"]
+    school_context = config["context"]["schools"]
+
+    df = athletes.merge(attention, on="athlete_id").merge(performance, on="athlete_id")
+
+    def _context_multiplier(row: pd.Series) -> float:
+        school_meta = school_context.get(
+            row["school"], {"market_size": 1.0, "tv_exposure": 1.0}
+        )
+        sport_multiplier = market_adjustment.get(row["sport"], 1.0)
+        return (
+            sport_multiplier
+            * school_meta.get("market_size", 1.0)
+            * school_meta.get("tv_exposure", 1.0)
+        )
+
+    df["context_multiplier"] = df.apply(_context_multiplier, axis=1)
+    df["adjusted_attention"] = df["attention_score"] * df["context_multiplier"]
+    df["adjusted_performance"] = df["performance_index"] * df["context_multiplier"]
+    df["as_of"] = datetime.now(UTC)
+    return df

--- a/models/repository.py
+++ b/models/repository.py
@@ -1,0 +1,145 @@
+"""Persistence helpers for loading data into the warehouse."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Iterable
+
+import pandas as pd
+from sqlalchemy import delete
+
+from .database import get_engine, session_scope
+from .schema import (
+    Athlete,
+    AthleteFeature,
+    AthleteValuation,
+    Base,
+    BoxScore,
+    SearchInterest,
+    SocialStat,
+)
+
+
+def initialize_database() -> None:
+    """Create database tables if they do not yet exist."""
+
+    engine = get_engine()
+    Base.metadata.create_all(engine)
+
+
+def upsert_athletes(df: pd.DataFrame) -> None:
+    records = df.to_dict(orient="records")
+    with session_scope() as session:
+        for record in records:
+            athlete = session.get(Athlete, record["athlete_id"])
+            if athlete is None:
+                athlete = Athlete(**record)
+                session.add(athlete)
+            else:
+                for key, value in record.items():
+                    setattr(athlete, key, value)
+
+
+def load_box_scores(df: pd.DataFrame) -> None:
+    with session_scope() as session:
+        session.execute(delete(BoxScore))
+        session.bulk_insert_mappings(BoxScore, df.to_dict(orient="records"))
+
+
+def load_social_stats(df: pd.DataFrame) -> None:
+    with session_scope() as session:
+        session.execute(delete(SocialStat))
+        payload = df.rename(columns={"date": "stat_date"}).to_dict(orient="records")
+        session.bulk_insert_mappings(SocialStat, payload)
+
+
+def load_search_interest(df: pd.DataFrame) -> None:
+    with session_scope() as session:
+        session.execute(delete(SearchInterest))
+        payload = df.rename(columns={"date": "stat_date"}).to_dict(orient="records")
+        session.bulk_insert_mappings(SearchInterest, payload)
+
+
+def store_features(df: pd.DataFrame) -> None:
+    with session_scope() as session:
+        session.execute(delete(AthleteFeature))
+        records = df.to_dict(orient="records")
+        session.bulk_insert_mappings(AthleteFeature, records)
+
+
+def store_valuations(df: pd.DataFrame) -> None:
+    with session_scope() as session:
+        session.execute(delete(AthleteValuation))
+        records = df.to_dict(orient="records")
+        session.bulk_insert_mappings(AthleteValuation, records)
+
+
+def fetch_leaderboard(limit: int = 100) -> list[dict]:
+    with session_scope() as session:
+        rows = (
+            session.query(AthleteValuation, Athlete)
+            .join(Athlete, AthleteValuation.athlete_id == Athlete.athlete_id)
+            .order_by(AthleteValuation.nil_value.desc())
+            .limit(limit)
+            .all()
+        )
+        results: list[dict] = []
+        for valuation, athlete in rows:
+            results.append(
+                {
+                    "athlete_id": athlete.athlete_id,
+                    "name": athlete.name,
+                    "sport": athlete.sport,
+                    "school": athlete.school,
+                    "nil_value": float(valuation.nil_value),
+                    "as_of": valuation.as_of,
+                    "attention_score": valuation.attention_score,
+                    "performance_index": valuation.performance_index,
+                }
+            )
+        return results
+
+
+def fetch_athlete_valuation(athlete_id: str) -> dict | None:
+    with session_scope() as session:
+        row = (
+            session.query(AthleteValuation, Athlete)
+            .join(Athlete, AthleteValuation.athlete_id == Athlete.athlete_id)
+            .filter(AthleteValuation.athlete_id == athlete_id)
+            .order_by(AthleteValuation.as_of.desc())
+            .first()
+        )
+        if row is None:
+            return None
+        valuation, athlete = row
+        return {
+            "athlete_id": athlete.athlete_id,
+            "name": athlete.name,
+            "sport": athlete.sport,
+            "school": athlete.school,
+            "as_of": valuation.as_of,
+            "nil_value": float(valuation.nil_value),
+            "confidence_lower": float(valuation.confidence_lower),
+            "confidence_upper": float(valuation.confidence_upper),
+            "attention_score": valuation.attention_score,
+            "performance_index": valuation.performance_index,
+        }
+
+
+def fetch_athlete_features(athlete_id: str) -> list[dict]:
+    with session_scope() as session:
+        rows = (
+            session.query(AthleteFeature)
+            .filter(AthleteFeature.athlete_id == athlete_id)
+            .order_by(AthleteFeature.as_of.desc())
+            .all()
+        )
+        return [
+            {
+                "athlete_id": row.athlete_id,
+                "as_of": row.as_of,
+                "attention_score": row.attention_score,
+                "performance_index": row.performance_index,
+            }
+            for row in rows
+        ]

--- a/models/schema.py
+++ b/models/schema.py
@@ -1,0 +1,92 @@
+"""SQLAlchemy ORM models for the NIL valuation warehouse."""
+
+from __future__ import annotations
+
+from datetime import date, datetime
+
+from sqlalchemy import Date, DateTime, Float, ForeignKey, Integer, Numeric, String
+from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column, relationship
+
+
+class Base(DeclarativeBase):
+    """Base declarative class."""
+
+
+class Athlete(Base):
+    __tablename__ = "athletes"
+
+    athlete_id: Mapped[str] = mapped_column(String(64), primary_key=True)
+    name: Mapped[str] = mapped_column(String(128), nullable=False)
+    sport: Mapped[str] = mapped_column(String(64), nullable=False)
+    school: Mapped[str] = mapped_column(String(128), nullable=False)
+
+    box_scores: Mapped[list["BoxScore"]] = relationship(back_populates="athlete")
+    valuations: Mapped[list["AthleteValuation"]] = relationship(back_populates="athlete")
+
+
+class BoxScore(Base):
+    __tablename__ = "box_scores"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    athlete_id: Mapped[str] = mapped_column(ForeignKey("athletes.athlete_id"), nullable=False)
+    game_date: Mapped[date] = mapped_column(Date, nullable=False)
+    opponent: Mapped[str] = mapped_column(String(128), nullable=False)
+    points: Mapped[float] = mapped_column(Float, nullable=False)
+    assists: Mapped[float] = mapped_column(Float, nullable=False)
+    rebounds: Mapped[float] = mapped_column(Float, nullable=False)
+    efficiency: Mapped[float] = mapped_column(Float, nullable=False)
+    minutes: Mapped[float] = mapped_column(Float, nullable=False)
+
+    athlete: Mapped[Athlete] = relationship(back_populates="box_scores")
+
+
+class SocialStat(Base):
+    __tablename__ = "social_stats"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    athlete_id: Mapped[str] = mapped_column(ForeignKey("athletes.athlete_id"), nullable=False)
+    channel: Mapped[str] = mapped_column(String(32), nullable=False)
+    stat_date: Mapped[date] = mapped_column(Date, nullable=False)
+    followers: Mapped[int] = mapped_column(Integer, nullable=False)
+    engagement_rate: Mapped[float] = mapped_column(Float, nullable=False)
+    growth_rate: Mapped[float] = mapped_column(Float, nullable=False)
+
+    athlete: Mapped[Athlete] = relationship()
+
+
+class SearchInterest(Base):
+    __tablename__ = "search_interest"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    athlete_id: Mapped[str] = mapped_column(ForeignKey("athletes.athlete_id"), nullable=False)
+    stat_date: Mapped[date] = mapped_column(Date, nullable=False)
+    interest_score: Mapped[int] = mapped_column(Integer, nullable=False)
+
+    athlete: Mapped[Athlete] = relationship()
+
+
+class AthleteFeature(Base):
+    __tablename__ = "athlete_features"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    athlete_id: Mapped[str] = mapped_column(ForeignKey("athletes.athlete_id"), nullable=False)
+    as_of: Mapped[datetime] = mapped_column(DateTime, nullable=False)
+    attention_score: Mapped[float] = mapped_column(Float, nullable=False)
+    performance_index: Mapped[float] = mapped_column(Float, nullable=False)
+
+    athlete: Mapped[Athlete] = relationship()
+
+
+class AthleteValuation(Base):
+    __tablename__ = "athlete_valuations"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    athlete_id: Mapped[str] = mapped_column(ForeignKey("athletes.athlete_id"), nullable=False)
+    as_of: Mapped[datetime] = mapped_column(DateTime, nullable=False)
+    nil_value: Mapped[float] = mapped_column(Numeric(12, 2), nullable=False)
+    confidence_lower: Mapped[float] = mapped_column(Numeric(12, 2), nullable=False)
+    confidence_upper: Mapped[float] = mapped_column(Numeric(12, 2), nullable=False)
+    attention_score: Mapped[float] = mapped_column(Float, nullable=False)
+    performance_index: Mapped[float] = mapped_column(Float, nullable=False)
+
+    athlete: Mapped[Athlete] = relationship(back_populates="valuations")

--- a/models/training.py
+++ b/models/training.py
@@ -1,0 +1,174 @@
+"""Model training utilities for the NIL valuation pipeline."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import Dict, Tuple
+
+import numpy as np
+import pandas as pd
+from lightgbm import LGBMRegressor
+from sklearn.metrics import mean_squared_error
+
+from bsi_nil.config import load_config
+
+
+@dataclass
+class TrainedModels:
+    stage_a: LGBMRegressor
+    stage_b: LGBMRegressor
+    residual_std: float
+
+
+@dataclass
+class TrainingArtifacts:
+    stage_a_rmse: float
+    stage_b_rmse: float
+
+
+def _prepare_stage_a_data(
+    social_stats: pd.DataFrame, search_interest: pd.DataFrame, attention: pd.DataFrame
+) -> Tuple[pd.DataFrame, pd.Series, pd.Series]:
+    social_features = (
+        social_stats.groupby("athlete_id")
+        .agg(
+            followers_mean=("followers", "mean"),
+            engagement_mean=("engagement_rate", "mean"),
+            growth_mean=("growth_rate", "mean"),
+        )
+        .reset_index()
+    )
+
+    search_features = (
+        search_interest.groupby("athlete_id")
+        .agg(
+            search_mean=("interest_score", "mean"),
+            search_max=("interest_score", "max"),
+        )
+        .reset_index()
+    )
+
+    df = social_features.merge(search_features, on="athlete_id", how="outer").fillna(0.0)
+    df = df.merge(attention[["athlete_id", "attention_score"]], on="athlete_id")
+
+    X = df.drop(columns=["athlete_id", "attention_score"])
+    y = df["attention_score"]
+    ids = df["athlete_id"]
+    return X, y, ids
+
+
+def _prepare_stage_b_data(
+    features: pd.DataFrame,
+    stage_a_predictions: pd.DataFrame,
+    nil_deals: pd.DataFrame,
+) -> Tuple[pd.DataFrame, pd.Series]:
+    training_df = features.merge(
+        stage_a_predictions[["athlete_id", "predicted_attention"]], on="athlete_id"
+    )
+    deals = (
+        nil_deals.groupby("athlete_id")[["value"]]
+        .mean()
+        .rename(columns={"value": "nil_value"})
+        .reset_index()
+    )
+    training_df = training_df.merge(deals, on="athlete_id", how="inner")
+
+    X = training_df[["predicted_attention", "adjusted_performance", "context_multiplier"]]
+    y = training_df["nil_value"]
+    return X, y
+
+
+def train_models(
+    social_stats: pd.DataFrame,
+    search_interest: pd.DataFrame,
+    features: pd.DataFrame,
+    nil_deals: pd.DataFrame,
+) -> Tuple[TrainedModels, TrainingArtifacts, pd.DataFrame]:
+    """Train Stage A and Stage B models and return predictions."""
+
+    config = load_config()
+    stage_a_params: Dict[str, float] = config["modeling"]["stage_a_params"]
+    stage_b_params: Dict[str, float] = config["modeling"]["stage_b_params"]
+
+    X_a, y_a, ids = _prepare_stage_a_data(social_stats, search_interest, features)
+    stage_a_model = LGBMRegressor(random_state=42, **stage_a_params)
+    stage_a_model.fit(X_a, y_a)
+    stage_a_pred = stage_a_model.predict(X_a)
+    stage_a_rmse = float(np.sqrt(mean_squared_error(y_a, stage_a_pred)))
+
+    stage_a_predictions = pd.DataFrame(
+        {
+            "athlete_id": ids,
+            "predicted_attention": stage_a_pred,
+        }
+    )
+
+    X_b, y_b = _prepare_stage_b_data(features, stage_a_predictions, nil_deals)
+    stage_b_model = LGBMRegressor(random_state=21, **stage_b_params)
+    stage_b_model.fit(X_b, y_b)
+    stage_b_pred = stage_b_model.predict(X_b)
+    stage_b_rmse = float(np.sqrt(mean_squared_error(y_b, stage_b_pred)))
+
+    residual_std = float(np.std(y_b - stage_b_pred, ddof=1)) if len(y_b) > 1 else 15_000.0
+
+    models = TrainedModels(
+        stage_a=stage_a_model,
+        stage_b=stage_b_model,
+        residual_std=residual_std,
+    )
+    artifacts = TrainingArtifacts(stage_a_rmse=stage_a_rmse, stage_b_rmse=stage_b_rmse)
+    return models, artifacts, stage_a_predictions
+
+
+def generate_valuations(
+    features: pd.DataFrame,
+    stage_a_predictions: pd.DataFrame,
+    models: TrainedModels,
+    game_counts: pd.Series,
+) -> pd.DataFrame:
+    """Produce NIL valuations and apply Bayesian shrinkage and confidence bands."""
+
+    config = load_config()["modeling"]
+    shrinkage_prior = config["shrinkage_prior"]
+    shrinkage_strength = config["shrinkage_strength"]
+
+    df = features.merge(stage_a_predictions, on="athlete_id", how="left")
+    df["predicted_attention"] = df["predicted_attention"].fillna(df["attention_score"])
+
+    X_predict = df[["predicted_attention", "adjusted_performance", "context_multiplier"]].fillna(0.0)
+    base_pred = models.stage_b.predict(X_predict)
+    base_pred = np.nan_to_num(base_pred, nan=shrinkage_prior)
+
+    df["raw_nil_value"] = base_pred
+
+    counts = game_counts.reindex(df["athlete_id"]).fillna(0).astype(float)
+    df["game_counts"] = counts.values
+
+    df["shrinkage_factor"] = counts / (counts + shrinkage_strength)
+    df["shrunken_value"] = (
+        shrinkage_prior * (1 - df["shrinkage_factor"]) + df["raw_nil_value"] * df["shrinkage_factor"]
+    )
+    df["shrunken_value"] = df["shrunken_value"].fillna(shrinkage_prior)
+
+    z_score = 1.645  # 90% confidence
+    residual_std = max(models.residual_std, 5_000.0)
+    df["ci_margin"] = np.nan_to_num(z_score * residual_std, nan=shrinkage_prior)
+
+    valuations = df.assign(
+        nil_value=df["shrunken_value"].astype(float),
+        confidence_lower=np.maximum(df["shrunken_value"] - df["ci_margin"], 0).astype(float),
+        confidence_upper=(df["shrunken_value"] + df["ci_margin"]).astype(float),
+        as_of=datetime.now(UTC),
+    )[
+        [
+            "athlete_id",
+            "as_of",
+            "nil_value",
+            "confidence_lower",
+            "confidence_upper",
+            "attention_score",
+            "performance_index",
+        ]
+    ]
+    return valuations

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+testpaths = tests

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,16 @@
 numpy>=1.24.0
 pandas>=2.0.0
+scipy>=1.10.0
 matplotlib>=3.7.0
 seaborn>=0.12.0
-scipy>=1.10.0
+SQLAlchemy>=2.0.0
+psycopg2-binary>=2.9.0
+prefect>=2.10.0
+lightgbm>=4.0.0
+scikit-learn>=1.3.0
+fastapi>=0.103.0
+uvicorn[standard]>=0.23.0
+redis>=5.0.0
+pyyaml>=6.0.0
+pydantic>=2.3.0
+python-dotenv>=1.0.0

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1,0 +1,61 @@
+"""Integration-style tests for the NIL valuation scaffold."""
+
+from __future__ import annotations
+
+import importlib
+from pathlib import Path
+
+import yaml
+from fastapi.testclient import TestClient
+
+from bsi_nil.config import reset_config_cache
+from etl.flows import nightly_pipeline
+from models.database import reset_engine
+
+
+def _prepare_test_config(tmp_path: Path) -> Path:
+    base_config_path = Path("config/settings.yaml")
+    config = yaml.safe_load(base_config_path.read_text())
+    database_path = tmp_path / "test.db"
+    config["database"]["url"] = f"sqlite+pysqlite:///{database_path}"
+    config["storage"]["raw_path"] = str(tmp_path / "raw")
+    config_path = tmp_path / "test_config.yaml"
+    config_path.write_text(yaml.safe_dump(config))
+    return config_path
+
+
+def test_pipeline_runs_end_to_end(tmp_path, monkeypatch):
+    config_path = _prepare_test_config(tmp_path)
+    monkeypatch.setenv("BLAZE_CONFIG", str(config_path))
+    reset_config_cache()
+    reset_engine()
+
+    result = nightly_pipeline()
+    assert result["backtest"].coverage >= 0
+    assert result["artifacts"].stage_a_rmse >= 0
+
+
+def test_api_endpoints_return_data(tmp_path, monkeypatch):
+    config_path = _prepare_test_config(tmp_path)
+    monkeypatch.setenv("BLAZE_CONFIG", str(config_path))
+    reset_config_cache()
+    reset_engine()
+
+    nightly_pipeline()
+
+    # Reload API module to pick up new configuration
+    api_main = importlib.import_module("api.main")
+    importlib.reload(api_main)
+
+    with TestClient(api_main.app) as client:
+        leaderboard = client.get("/leaderboard")
+        assert leaderboard.status_code == 200
+        payload = leaderboard.json()
+        assert payload["results"]
+        athlete_id = payload["results"][0]["athlete_id"]
+
+        athlete_resp = client.get(f"/athlete/{athlete_id}/value")
+        assert athlete_resp.status_code == 200
+        athlete_payload = athlete_resp.json()
+        assert athlete_payload["athlete_id"] == athlete_id
+        assert "Estimated value, not contractual" in athlete_payload["disclaimer"]


### PR DESCRIPTION
## Summary
- add configuration utilities and YAML config for the Blaze Sports Intel NIL pipeline
- implement Prefect-based ETL, feature engineering, LightGBM modeling, and persistence helpers with mock data sources
- expose FastAPI endpoints with Redis-backed caching and integration tests for the nightly pipeline and API

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68d714e4d40c8330b75766a34b8770ab