### PR TITLE
Add sanitized MCP configuration examples

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -122,3 +122,22 @@ HOT_RELOAD=true
 MOCK_EXTERNAL_APIS=true
 VERBOSE_LOGGING=false
 PROFILE_PERFORMANCE=false
+# ==================== MCP / CONTEXT7 ====================
+CONTEXT7_API_KEY=your_context7_api_key
+CONTEXT7_API_URL=https://context7.com/api/v1
+CONTEXT7_MCP_URL=https://mcp.context7.com/mcp
+
+# ==================== MCP CONNECTORS ====================
+GITHUB_TOKEN=ghp_your_token
+GITHUB_REPOSITORY=Blaze-Intelligence/BSI
+GITHUB_BASE_URL=https://api.github.com
+OPENAI_API_KEY=your_openai_key_here
+OPENAI_BASE_URL=https://api.openai.com/v1
+OPENAI_ORGANIZATION=org_your_openai_org
+ANTHROPIC_API_KEY=your_anthropic_key_here
+CLOUDFLARE_ACCOUNT_ID=your_account_id_here
+CLOUDFLARE_API_TOKEN=your_api_token_here
+CLOUDFLARE_API_BASE_URL=https://api.cloudflare.com/client/v4
+SLACK_BOT_TOKEN=xoxb-your-bot-token
+SLACK_SIGNING_SECRET=your-signing-secret
+

--- a/config.context7.toml
+++ b/config.context7.toml
@@ -1,0 +1,14 @@
+[client]
+model = "gpt-5-codex"
+model_reasoning_effort = "high"
+
+[[mcp_servers]]
+id = "context7"
+command = "npx"
+args = ["-y", "@context7/mcp-server"]
+transport = "stdio"
+env = {
+  CONTEXT7_API_KEY = "${CONTEXT7_API_KEY}",
+  CONTEXT7_API_URL = "${CONTEXT7_API_URL}",
+  CONTEXT7_MCP_URL = "${CONTEXT7_MCP_URL}"
+}

--- a/config.full.sanitized.toml
+++ b/config.full.sanitized.toml
@@ -1,0 +1,66 @@
+[client]
+model = "gpt-5-codex"
+model_reasoning_effort = "high"
+
+[[mcp_servers]]
+id = "context7"
+command = "npx"
+args = ["-y", "@context7/mcp-server"]
+transport = "stdio"
+env = {
+  CONTEXT7_API_KEY = "${CONTEXT7_API_KEY}",
+  CONTEXT7_API_URL = "${CONTEXT7_API_URL}",
+  CONTEXT7_MCP_URL = "${CONTEXT7_MCP_URL}"
+}
+
+[[mcp_servers]]
+id = "github"
+command = "npx"
+args = ["-y", "@modelcontextprotocol/server-github"]
+transport = "stdio"
+env = {
+  GITHUB_TOKEN = "${GITHUB_TOKEN}",
+  GITHUB_REPOSITORY = "${GITHUB_REPOSITORY}",
+  GITHUB_BASE_URL = "${GITHUB_BASE_URL}"
+}
+
+[[mcp_servers]]
+id = "openai"
+command = "npx"
+args = ["-y", "@modelcontextprotocol/server-openai"]
+transport = "stdio"
+env = {
+  OPENAI_API_KEY = "${OPENAI_API_KEY}",
+  OPENAI_BASE_URL = "${OPENAI_BASE_URL}",
+  OPENAI_ORGANIZATION = "${OPENAI_ORGANIZATION}"
+}
+
+[[mcp_servers]]
+id = "anthropic"
+command = "npx"
+args = ["-y", "@modelcontextprotocol/server-anthropic"]
+transport = "stdio"
+env = {
+  ANTHROPIC_API_KEY = "${ANTHROPIC_API_KEY}"
+}
+
+[[mcp_servers]]
+id = "cloudflare"
+command = "npx"
+args = ["-y", "@modelcontextprotocol/server-cloudflare"]
+transport = "stdio"
+env = {
+  CLOUDFLARE_ACCOUNT_ID = "${CLOUDFLARE_ACCOUNT_ID}",
+  CLOUDFLARE_API_TOKEN = "${CLOUDFLARE_API_TOKEN}",
+  CLOUDFLARE_API_BASE_URL = "${CLOUDFLARE_API_BASE_URL}"
+}
+
+[[mcp_servers]]
+id = "slack"
+command = "npx"
+args = ["-y", "@modelcontextprotocol/server-slack"]
+transport = "stdio"
+env = {
+  SLACK_BOT_TOKEN = "${SLACK_BOT_TOKEN}",
+  SLACK_SIGNING_SECRET = "${SLACK_SIGNING_SECRET}"
+}


### PR DESCRIPTION
## Summary
- add a minimal Context7-only MCP configuration that reads secrets from environment variables
- provide a sanitized multi-connector MCP config mirroring the expanded setup
- extend the sample environment file with the required Context7 and connector variables

## Testing
- not run (configuration and documentation-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68d9bceac0208330a550b087b33a504d