### PR TITLE
Add NCAA API endpoints with caching and analytics

### DIFF
--- a/functions/api/_utils.js
+++ b/functions/api/_utils.js
@@ -1,0 +1,102 @@
+const DEFAULT_CORS_HEADERS = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Methods': 'GET, OPTIONS',
+  'Access-Control-Allow-Headers': 'Content-Type, Accept',
+};
+
+export const corsHeaders = {
+  ...DEFAULT_CORS_HEADERS,
+  'Content-Type': 'application/json',
+};
+
+export const ok = (data, init = {}) =>
+  new Response(JSON.stringify(data), {
+    status: init.status ?? 200,
+    headers: {
+      ...corsHeaders,
+      ...(init.headers || {}),
+    },
+  });
+
+export const err = (error, status = 500, init = {}) => {
+  const message =
+    error instanceof Error && error.message ? error.message : 'Internal Server Error';
+
+  return new Response(
+    JSON.stringify({
+      error: message,
+    }),
+    {
+      status,
+      headers: {
+        ...corsHeaders,
+        ...(init.headers || {}),
+      },
+    },
+  );
+};
+
+const getCacheBinding = (env) => {
+  if (!env || typeof env !== 'object') {
+    return null;
+  }
+
+  const candidates = ['CACHE', 'KV', 'kv', 'cache'];
+  for (const key of candidates) {
+    const binding = env[key];
+    if (binding && typeof binding.get === 'function' && typeof binding.put === 'function') {
+      return binding;
+    }
+  }
+
+  return null;
+};
+
+export const cache = async (env, key, fetcher, ttl = 300) => {
+  const store = getCacheBinding(env);
+  if (!store || typeof fetcher !== 'function') {
+    return fetcher();
+  }
+
+  const now = Date.now();
+  try {
+    const cached = await store.get(key);
+    if (cached) {
+      const parsed = JSON.parse(cached);
+      if (parsed && parsed.expires && parsed.expires > now) {
+        return parsed.data;
+      }
+    }
+  } catch (error) {
+    console.warn(`Cache read miss for key ${key}:`, error);
+  }
+
+  const fresh = await fetcher();
+
+  try {
+    await store.put(
+      key,
+      JSON.stringify({
+        data: fresh,
+        expires: now + ttl * 1000,
+      }),
+      { expirationTtl: ttl },
+    );
+  } catch (error) {
+    console.warn(`Cache write failed for key ${key}:`, error);
+  }
+
+  return fresh;
+};
+
+export const preflight = () => new Response(null, { headers: corsHeaders });
+
+export const createTimeoutSignal = (timeoutMs = 8000) => {
+  if (typeof AbortSignal !== 'undefined' && typeof AbortSignal.timeout === 'function') {
+    return AbortSignal.timeout(timeoutMs);
+  }
+
+  const controller = new AbortController();
+  setTimeout(() => controller.abort(), timeoutMs).unref?.();
+  return controller.signal;
+};

--- a/functions/api/ncaa/scores.js
+++ b/functions/api/ncaa/scores.js
@@ -1,0 +1,156 @@
+import { createTimeoutSignal, err, ok, preflight } from '../_utils.js';
+
+const BASE_URL = 'https://site.api.espn.com/apis/site/v2/sports/football/college-football/scoreboard';
+const FETCH_TIMEOUT_MS = 6000;
+
+const defaultHeaders = {
+  'User-Agent': 'BlazeSportsIntel/1.0 (+https://blazesportsintel.com)',
+  Accept: 'application/json',
+  'Accept-Language': 'en-US,en;q=0.9',
+  Referer: 'https://blazesportsintel.com/',
+};
+
+export async function onRequest(context) {
+  const { request, waitUntil } = context;
+
+  if (request.method === 'OPTIONS') {
+    return preflight();
+  }
+
+  const url = new URL(request.url);
+  const week = sanitizeWeek(url.searchParams.get('week'));
+  const conference = sanitizeConference(url.searchParams.get('conference'));
+
+  try {
+    const edgeCache = caches?.default;
+
+    if (edgeCache) {
+      const cachedResponse = await edgeCache.match(request);
+      if (cachedResponse) {
+        return cachedResponse;
+      }
+    }
+
+    const data = await fetchScores(week, conference);
+    const response = ok(data, {
+      headers: {
+        'Cache-Control': buildCacheControlHeader(data.games),
+      },
+    });
+
+    if (edgeCache && typeof waitUntil === 'function') {
+      waitUntil(edgeCache.put(request, response.clone()));
+    }
+
+    return response;
+  } catch (error) {
+    console.error('NCAA scores fetch error', error);
+    return err(error);
+  }
+}
+
+async function fetchScores(week, conference) {
+  const signal = createTimeoutSignal(FETCH_TIMEOUT_MS);
+  const query = buildQueryString(week, conference);
+  const response = await fetch(`${BASE_URL}${query}`, { headers: defaultHeaders, signal });
+
+  if (!response.ok) {
+    throw new Error(`ESPN scoreboard request failed with status ${response.status}`);
+  }
+
+  const data = await response.json();
+  const events = Array.isArray(data?.events) ? data.events : [];
+
+  return {
+    week: data?.week?.number ?? week,
+    season: data?.season?.year ?? null,
+    games: events.map(formatEvent),
+    meta: {
+      dataSource: 'ESPN Live Scores',
+      lastUpdated: new Date().toISOString(),
+    },
+  };
+}
+
+function formatEvent(event) {
+  const competition = Array.isArray(event?.competitions) ? event.competitions[0] : null;
+  const competitors = Array.isArray(competition?.competitors) ? competition.competitors : [];
+
+  return {
+    id: event?.id ?? null,
+    name: event?.name ?? null,
+    date: event?.date ?? null,
+    status: buildStatus(event?.status),
+    competition,
+    teams: competitors.map((team) => ({
+      id: team?.id ?? null,
+      team: team?.team ?? null,
+      homeAway: team?.homeAway ?? null,
+      rank: team?.rank ?? null,
+      score: team?.score ?? null,
+      winner: Boolean(team?.winner),
+      records: team?.records ?? [],
+      statistics: team?.statistics ?? [],
+      leaders: team?.leaders ?? [],
+    })),
+    odds: competition?.odds?.[0] ?? null,
+    broadcast: Array.isArray(competition?.broadcasts)
+      ? competition.broadcasts[0]
+      : null,
+    venue: competition?.venue ?? null,
+    weather: event?.weather ?? null,
+  };
+}
+
+function buildStatus(status) {
+  if (!status || typeof status !== 'object') {
+    return null;
+  }
+
+  return {
+    type: status?.type?.name ?? null,
+    completed: Boolean(status?.type?.completed),
+    detail: status?.type?.detail ?? null,
+    period: status?.period ?? null,
+    clock: status?.displayClock ?? null,
+  };
+}
+
+function buildCacheControlHeader(games) {
+  const completed = Array.isArray(games)
+    ? games.every((game) => game?.status?.completed)
+    : false;
+
+  const ttl = completed ? 300 : 30;
+  return `public, max-age=${ttl}`;
+}
+
+function buildQueryString(week, conference) {
+  const params = new URLSearchParams();
+  if (week && week !== 'current') {
+    params.set('week', week);
+  }
+  if (conference) {
+    params.set('group', conference);
+  }
+  const query = params.toString();
+  return query ? `?${query}` : '';
+}
+
+function sanitizeWeek(value) {
+  if (!value || value === 'current') {
+    return 'current';
+  }
+
+  const numeric = Number.parseInt(value, 10);
+  return Number.isInteger(numeric) && numeric > 0 && numeric <= 20 ? numeric.toString() : 'current';
+}
+
+function sanitizeConference(value) {
+  if (!value) {
+    return '';
+  }
+
+  return /^\d{1,4}$/.test(value) ? value : '';
+}
+

--- a/functions/api/ncaa/standings.js
+++ b/functions/api/ncaa/standings.js
@@ -1,0 +1,184 @@
+import { cache, createTimeoutSignal, err, ok, preflight } from '../_utils.js';
+
+const BASE_URL = 'https://site.api.espn.com/apis/v2/sports/football/college-football/standings';
+const RANKINGS_URL = 'https://site.api.espn.com/apis/site/v2/sports/football/college-football/rankings';
+const FETCH_TIMEOUT_MS = 8000;
+
+const defaultHeaders = {
+  'User-Agent': 'BlazeSportsIntel/1.0 (+https://blazesportsintel.com)',
+  Accept: 'application/json',
+  'Accept-Language': 'en-US,en;q=0.9',
+  Referer: 'https://blazesportsintel.com/',
+};
+
+export async function onRequest(context) {
+  const { request, env } = context;
+
+  if (request.method === 'OPTIONS') {
+    return preflight();
+  }
+
+  const url = new URL(request.url);
+  const conference = sanitizeConference(url.searchParams.get('conference'));
+  const division = sanitizeDivision(url.searchParams.get('division'));
+
+  try {
+    const data = await cache(
+      env,
+      `ncaa:standings:${conference}:${division}`,
+      async () => fetchStandings(conference, division),
+      300,
+    );
+
+    return ok(data, {
+      headers: {
+        'Cache-Control': 'public, max-age=120, s-maxage=300',
+      },
+    });
+  } catch (error) {
+    console.error('NCAA standings fetch error', error);
+    return err(error);
+  }
+}
+
+async function fetchStandings(conference, division) {
+  const signal = createTimeoutSignal(FETCH_TIMEOUT_MS);
+  const standingsUrl = conference === 'all' ? BASE_URL : `${BASE_URL}?group=${conference}`;
+  const standings = await fetchJson(standingsUrl, signal, 'standings');
+
+  const conferences = Array.isArray(standings?.children) ? standings.children : [];
+
+  const standingsPayload = conferences
+    .map((group) => buildConference(group, division))
+    .filter(Boolean);
+
+  return {
+    standings: standingsPayload,
+    rankings: {
+      apTop25: await fetchRankings(`${RANKINGS_URL}`, signal),
+      cfpRankings: await fetchRankings(`${RANKINGS_URL}?type=cfp`, signal),
+    },
+    meta: {
+      dataSource: 'ESPN College Football API',
+      lastUpdated: new Date().toISOString(),
+    },
+  };
+}
+
+async function fetchJson(url, signal, label) {
+  const response = await fetch(url, { headers: defaultHeaders, signal });
+  if (!response.ok) {
+    throw new Error(`ESPN ${label} request failed with status ${response.status}`);
+  }
+  return response.json();
+}
+
+async function fetchRankings(url, signal) {
+  try {
+    const data = await fetchJson(url, signal, 'rankings');
+    const ranks = Array.isArray(data?.rankings?.[0]?.ranks) ? data.rankings[0].ranks : [];
+    return ranks.slice(0, 25).map((rank) => ({
+      rank: rank?.current ?? null,
+      team: {
+        id: rank?.team?.id ?? null,
+        name: rank?.team?.displayName ?? null,
+        abbreviation: rank?.team?.abbreviation ?? null,
+        logo: rank?.team?.logos?.[0]?.href ?? null,
+      },
+      record: rank?.record ?? null,
+    }));
+  } catch (error) {
+    console.warn('Unable to fetch rankings', error);
+    return [];
+  }
+}
+
+function buildConference(group, divisionFilter) {
+  if (!group || typeof group !== 'object') {
+    return null;
+  }
+
+  const divisions = Array.isArray(group.children) ? group.children : [];
+
+  return {
+    name: group.name ?? null,
+    abbreviation: group.abbreviation ?? null,
+    divisions: divisions
+      .filter((division) => !divisionFilter || matchesDivision(division, divisionFilter))
+      .map((division) => ({
+        name: division.name ?? null,
+        teams: buildTeams(division?.standings?.entries),
+      })),
+  };
+}
+
+function buildTeams(entries) {
+  if (!Array.isArray(entries)) {
+    return [];
+  }
+
+  return entries
+    .filter((entry) => entry)
+    .map((entry) => ({
+      rank: getStat(entry, 'rank'),
+      team: {
+        id: entry.team?.id ?? null,
+        name: entry.team?.displayName ?? null,
+        abbreviation: entry.team?.abbreviation ?? null,
+        logo: entry.team?.logos?.[0]?.href ?? null,
+      },
+      record: {
+        overall: getDisplayStat(entry, 'overall'),
+        conference: getDisplayStat(entry, 'vs. Conf.'),
+        home: getDisplayStat(entry, 'home'),
+        away: getDisplayStat(entry, 'road'),
+      },
+      stats: {
+        wins: getStat(entry, 'wins'),
+        losses: getStat(entry, 'losses'),
+        winPercent: getStat(entry, 'winPercent'),
+        gamesBack: getDisplayStat(entry, 'gamesBehind'),
+        streak: getDisplayStat(entry, 'streak'),
+        pointsFor: getStat(entry, 'pointsFor'),
+        pointsAgainst: getStat(entry, 'pointsAgainst'),
+      },
+    }));
+}
+
+function getStat(entry, name) {
+  const stats = Array.isArray(entry?.stats) ? entry.stats : [];
+  const stat = stats.find((item) => item?.name === name);
+  return stat?.value ?? null;
+}
+
+function getDisplayStat(entry, name) {
+  const stats = Array.isArray(entry?.stats) ? entry.stats : [];
+  const stat = stats.find((item) => item?.name === name);
+  return stat?.displayValue ?? null;
+}
+
+function sanitizeConference(value) {
+  if (!value || value === 'all') {
+    return 'all';
+  }
+
+  return /^\d{1,4}$/.test(value) ? value : 'all';
+}
+
+function sanitizeDivision(value) {
+  if (!value) {
+    return '';
+  }
+
+  const normalized = value.trim().toLowerCase();
+  return ['fbs', 'fcs', 'group of five', 'power five'].includes(normalized) ? normalized : '';
+}
+
+function matchesDivision(division, filter) {
+  if (!filter) {
+    return true;
+  }
+
+  const name = (division?.name || '').toLowerCase();
+  return name.includes(filter);
+}

--- a/functions/api/ncaa/teams.js
+++ b/functions/api/ncaa/teams.js
@@ -1,0 +1,329 @@
+import { cache, createTimeoutSignal, err, ok, preflight } from '../_utils.js';
+
+const DEFAULT_TEAM_ID = '251';
+const DEFAULT_SEASON = new Date().getUTCFullYear().toString();
+const FETCH_TIMEOUT_MS = 8000;
+const BASE_URL = 'https://site.api.espn.com/apis/site/v2/sports/football/college-football';
+
+const defaultHeaders = {
+  'User-Agent': 'BlazeSportsIntel/1.0 (+https://blazesportsintel.com)',
+  Accept: 'application/json',
+  'Accept-Language': 'en-US,en;q=0.9',
+  Referer: 'https://blazesportsintel.com/',
+};
+
+export async function onRequest(context) {
+  const { request, env } = context;
+
+  if (request.method === 'OPTIONS') {
+    return preflight();
+  }
+
+  const url = new URL(request.url);
+  const teamId = sanitizeTeamId(url.searchParams.get('teamId'));
+  const season = sanitizeSeason(url.searchParams.get('season'));
+
+  try {
+    const ttl = env?.NODE_ENV === 'production' ? 300 : 60;
+    const data = await cache(
+      env,
+      `ncaa:team:${teamId}:${season}`,
+      async () => fetchTeamData(teamId, season),
+      ttl,
+    );
+
+    return ok(data, {
+      headers: {
+        'Cache-Control': `public, max-age=${Math.min(ttl, 60)}, s-maxage=${ttl}`,
+      },
+    });
+  } catch (error) {
+    console.error('NCAA team fetch error', error);
+    return err(error);
+  }
+}
+
+async function fetchTeamData(teamId, season) {
+  const signal = createTimeoutSignal(FETCH_TIMEOUT_MS);
+
+  const [team, roster, schedule] = await Promise.all([
+    fetchJson(`${BASE_URL}/teams/${teamId}?season=${season}`, signal, 'team'),
+    fetchJson(`${BASE_URL}/teams/${teamId}/roster?season=${season}`, signal, 'roster'),
+    fetchJson(`${BASE_URL}/teams/${teamId}/schedule?season=${season}`, signal, 'schedule'),
+  ]);
+
+  const stats = Array.isArray(team?.team?.statistics)
+    ? team.team.statistics
+    : Array.isArray(team?.team?.stats)
+    ? team.team.stats
+    : [];
+
+  const recordItem = Array.isArray(team?.team?.record?.items)
+    ? team.team.record.items[0]
+    : null;
+
+  const conference = Array.isArray(team?.team?.groups)
+    ? sanitizeConference(team.team.groups[0])
+    : null;
+
+  const scheduleEvents = Array.isArray(schedule?.events) ? schedule.events : [];
+
+  return {
+    team: {
+      id: team?.team?.id ?? teamId,
+      school: team?.team?.school ?? null,
+      displayName: team?.team?.displayName ?? null,
+      nickname: team?.team?.nickname ?? null,
+      abbreviation: team?.team?.abbreviation ?? null,
+      color: team?.team?.color ?? null,
+      alternateColor: team?.team?.alternateColor ?? null,
+      logos: sanitizeLogos(team?.team?.logos),
+      venue: sanitizeVenue(team?.team?.venue),
+      conference,
+      record: buildRecord(recordItem),
+    },
+    roster: buildRoster(roster),
+    schedule: scheduleEvents.map((event) => buildScheduleEvent(event, teamId)),
+    analytics: {
+      pythagoreanWins: calculatePythagorean(stats),
+      strengthOfSchedule: calculateSOS(scheduleEvents, teamId),
+      efficiency: calculateEfficiency(stats),
+    },
+    meta: {
+      dataSource: 'ESPN College Football API',
+      lastUpdated: new Date().toISOString(),
+      season,
+    },
+  };
+}
+
+async function fetchJson(url, signal, label) {
+  const response = await fetch(url, {
+    headers: defaultHeaders,
+    signal,
+  });
+
+  if (!response.ok) {
+    throw new Error(`ESPN ${label} request failed with status ${response.status}`);
+  }
+
+  return response.json();
+}
+
+function sanitizeTeamId(value) {
+  if (!value) {
+    return DEFAULT_TEAM_ID;
+  }
+
+  const normalized = value.trim();
+  if (/^\d{1,6}$/.test(normalized)) {
+    return normalized;
+  }
+
+  return DEFAULT_TEAM_ID;
+}
+
+function sanitizeSeason(value) {
+  if (!value) {
+    return DEFAULT_SEASON;
+  }
+
+  const normalized = Number.parseInt(value, 10);
+  if (Number.isInteger(normalized) && normalized >= 2000 && normalized <= 2100) {
+    return normalized.toString();
+  }
+
+  return DEFAULT_SEASON;
+}
+
+function sanitizeConference(group) {
+  if (!group || typeof group !== 'object') {
+    return null;
+  }
+
+  return {
+    id: group.id ?? null,
+    name: group.name ?? null,
+    shortName: group.shortName ?? null,
+    abbreviation: group.abbreviation ?? null,
+  };
+}
+
+function sanitizeLogos(logos) {
+  if (!Array.isArray(logos)) {
+    return [];
+  }
+
+  return logos
+    .filter((logo) => logo && typeof logo === 'object')
+    .map((logo) => ({
+      href: logo.href ?? null,
+      width: logo.width ?? null,
+      height: logo.height ?? null,
+      alt: logo.alt ?? null,
+    }));
+}
+
+function sanitizeVenue(venue) {
+  if (!venue || typeof venue !== 'object') {
+    return null;
+  }
+
+  return {
+    id: venue.id ?? null,
+    fullName: venue.fullName ?? null,
+    address: venue.address ?? null,
+    capacity: venue.capacity ?? null,
+    indoor: venue.indoor ?? null,
+  };
+}
+
+function buildRecord(record) {
+  if (!record || typeof record !== 'object') {
+    return {
+      overall: '0-0',
+      conference: '0-0',
+      home: '0-0',
+      away: '0-0',
+    };
+  }
+
+  const stats = Array.isArray(record.stats) ? record.stats : [];
+
+  return {
+    overall: record.summary ?? '0-0',
+    conference: getDisplayValue(stats, 'vsConf'),
+    home: getDisplayValue(stats, 'home'),
+    away: getDisplayValue(stats, 'away'),
+  };
+}
+
+function getDisplayValue(stats, name) {
+  const stat = stats.find((item) => item?.name === name);
+  return stat?.displayValue ?? '0-0';
+}
+
+function buildRoster(roster) {
+  const athletes = roster?.athletes;
+  if (!Array.isArray(athletes)) {
+    return [];
+  }
+
+  return athletes
+    .filter((athlete) => athlete)
+    .map((athlete) => ({
+      id: athlete.id ?? null,
+      name: athlete.fullName ?? null,
+      jersey: athlete.jersey ?? null,
+      position: athlete.position?.abbreviation ?? null,
+      height: athlete.displayHeight ?? null,
+      weight: athlete.displayWeight ?? null,
+      year: athlete.experience?.displayValue ?? null,
+    }));
+}
+
+function buildScheduleEvent(event, teamId) {
+  const competition = Array.isArray(event?.competitions) ? event.competitions[0] : null;
+  const opponents = Array.isArray(competition?.competitors) ? competition.competitors : [];
+  const opponent = opponents.find((entry) => entry && entry.id !== teamId) ?? null;
+
+  return {
+    id: event?.id ?? null,
+    date: event?.date ?? null,
+    name: event?.name ?? null,
+    week: event?.week?.number ?? null,
+    venue: sanitizeVenue(competition?.venue),
+    opponent: opponent
+      ? {
+          id: opponent.id ?? null,
+          name: opponent.team?.displayName ?? null,
+          abbreviation: opponent.team?.abbreviation ?? null,
+          score: opponent.score ?? null,
+          record: Array.isArray(opponent.records) ? opponent.records : [],
+        }
+      : null,
+    result: competition?.status ?? null,
+    broadcast: Array.isArray(competition?.broadcasts)
+      ? sanitizeBroadcast(competition.broadcasts[0])
+      : null,
+  };
+}
+
+function sanitizeBroadcast(broadcast) {
+  if (!broadcast || typeof broadcast !== 'object') {
+    return null;
+  }
+
+  return {
+    name: broadcast.names?.[0] ?? null,
+    type: broadcast.type ?? null,
+    channel: broadcast.media?.shortName ?? null,
+  };
+}
+
+function calculatePythagorean(stats) {
+  const pointsFor = getNumericStat(stats, 'pointsFor');
+  const pointsAgainst = getNumericStat(stats, 'pointsAgainst');
+  const games = getNumericStat(stats, 'gamesPlayed');
+
+  if (pointsFor === 0 && pointsAgainst === 0) {
+    return 0;
+  }
+
+  const exponent = 2.37;
+  const numerator = Math.pow(pointsFor, exponent);
+  const denominator = numerator + Math.pow(pointsAgainst, exponent);
+
+  if (denominator === 0) {
+    return 0;
+  }
+
+  return Number(((numerator / denominator) * games).toFixed(1));
+}
+
+function calculateSOS(scheduleEvents, teamId) {
+  const completedGames = scheduleEvents.filter((game) =>
+    Boolean(game?.competitions?.[0]?.status?.type?.completed),
+  );
+
+  if (completedGames.length === 0) {
+    return 0;
+  }
+
+  const winPctSum = completedGames.reduce((total, game) => {
+    const competition = game.competitions?.[0];
+    const opponent = competition?.competitors?.find((comp) => comp.id !== teamId);
+    const summary = opponent?.records?.[0]?.summary;
+    if (!summary || typeof summary !== 'string') {
+      return total;
+    }
+
+    const [wins, losses] = summary.split('-').map((value) => Number.parseInt(value, 10));
+    if (!Number.isFinite(wins) || !Number.isFinite(losses) || wins + losses === 0) {
+      return total;
+    }
+
+    return total + wins / (wins + losses);
+  }, 0);
+
+  return Number((winPctSum / completedGames.length).toFixed(3));
+}
+
+function calculateEfficiency(stats) {
+  const yardsPerPlay = getNumericStat(stats, 'yardsPerPlay');
+  const turnovers = getNumericStat(stats, 'turnovers');
+  const games = Math.max(getNumericStat(stats, 'gamesPlayed'), 1);
+
+  const efficiency = yardsPerPlay * 10 - (turnovers / games) * 5;
+  return Number(efficiency.toFixed(1));
+}
+
+function getNumericStat(stats, name) {
+  if (!Array.isArray(stats)) {
+    return 0;
+  }
+
+  const match = stats.find((stat) => stat?.name === name);
+  const value = typeof match?.value === 'number' ? match.value : Number(match?.value);
+  return Number.isFinite(value) ? value : 0;
+}


### PR DESCRIPTION
## Summary
- add shared Cloudflare Pages function utilities for CORS handling, structured responses, and KV-backed caching helpers
- implement NCAA team endpoint with input sanitisation, analytics enrichment, and configurable TTL headers
- add NCAA standings and scoreboard endpoints with safe parameter handling, timeout-aware fetches, and edge caching

## Testing
- npm run lint *(fails: legacy Python files violate flake8 rules)*

------
https://chatgpt.com/codex/tasks/task_e_68d9e4620c4c833089a7dcadf106d992